### PR TITLE
Fix extra space after CC BY-SA 4.0

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer><p>
   &copy; {{ site.time | date: "%Y" }} Christophe Philemotte. All content on this site is available
-  under a <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0
-  </a>. The <a href="{{ site.code_url }}">code of the site</a> is
+  under a <a href="https://creativecommons.org/licenses/by-sa/4.0/">
+  CC BY-SA 4.0</a>. The <a href="{{ site.code_url }}">code of the site</a> is
   available under MIT license.
 </p></footer>
 


### PR DESCRIPTION
Was checking out your new site and spotted 🔎 there is an extra space.

Before

<img width="700" alt="screenshot 2016-08-18 17 25 31" src="https://cloud.githubusercontent.com/assets/1000669/17768906/db3772a6-6568-11e6-86d3-8738bed7b78b.png">

After

<img width="688" alt="screenshot 2016-08-18 17 25 50" src="https://cloud.githubusercontent.com/assets/1000669/17768896/d6740554-6568-11e6-83c6-67be19eb9bf4.png">

😊 